### PR TITLE
Added inputs and buttons to allow for PID tuning without opening the code

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,31 +31,31 @@
 		<label for="speedMax">SpeedMaxOutput:</label>
 		<input type="number" id="speedMax" name="speedMax" value="100">
 		<label for="speedKp">speedkP:</label>
-		<input type="number" id="speedKp" name="speedKp" value="0">
+		<input type="number" id="speedKp" name="speedKp" value="0" step="0.01">
 		<label for="speedKi">speedkI:</label>
-		<input type="number" id="speedKi" name="speedKi" value="0">
+		<input type="number" id="speedKi" name="speedKi" value="0" step="0.01">
 		<label for="speedKd">speedkD:</label>
-		<input type="number" id="speedKd" name="speedKd" value="0">
+		<input type="number" id="speedKd" name="speedKd" value="0" step="0.01">
 	</div>
 	<div>
 		<label for="angleMax">angleMaxOutput:</label>
 		<input type="number" id="angleMax" name="angleMax" value="30">
 		<label for="angleKp">anglekP:</label>
-		<input type="number" id="angleKp" name="angleKp" value="0">
+		<input type="number" id="angleKp" name="angleKp" value="0" step="0.01">
 		<label for="angleKi">anglekI:</label>
-		<input type="number" id="angleKi" name="angleKi" value="0">
+		<input type="number" id="angleKi" name="angleKi" value="0" step="0.01">
 		<label for="angleKd">anglekD:</label>
-		<input type="number" id="angleKd" name="angleKd" value="0">
+		<input type="number" id="angleKd" name="angleKd" value="0" step="0.01">
 	</div>
 	<div>
 		<label for="forceMax">forceMaxOutput:</label>
 		<input type="number" id="forceMax" name="forceMax" value="20">
 		<label for="forceKp">forcekP:</label>
-		<input type="number" id="forceKp" name="forceKp" value="0">
+		<input type="number" id="forceKp" name="forceKp" value="0" step="0.01">
 		<label for="forceKi">forcekI:</label>
-		<input type="number" id="forceKi" name="forceKi" value="0">
+		<input type="number" id="forceKi" name="forceKi" value="0" step="0.01">
 		<label for="forceKd">forcekD:</label>
-		<input type="number" id="forceKd" name="forceKd" value="0">
+		<input type="number" id="forceKd" name="forceKd" value="0" step="0.01">
 	</div>
 	<button id="resetSim">Reset Simulation</button>
 	<button id="updateSim">Update Target Position and PID Values</button>

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
 	</div>
 	<button id="resetSim">Reset Simulation</button>
 	<button id="updateSim">Update Target Position and PID Values</button>
-	<button id="setAcceptableValues">Set Parameters to usable values</button>
+	<button id="setAcceptableValues">Set Parameters to Usable Values</button>
 	<script type="module" src="matter_run.js"></script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
 	</div>
 	<div>
 		<label for="angleMax">angleMaxOutput:</label>
-		<input type="number" id="angleMax" name="angleMax" value="50">
+		<input type="number" id="angleMax" name="angleMax" value="30">
 		<label for="angleKp">anglekP:</label>
 		<input type="number" id="angleKp" name="angleKp" value="0">
 		<label for="angleKi">anglekI:</label>
@@ -58,6 +58,7 @@
 	</div>
 	<button id="resetSim">Reset Simulation</button>
 	<button id="updateSim">Update Target Position and PID Values</button>
+	<button id="setAcceptableValues">Set Parameters to usable values</button>
 	<script type="module" src="matter_run.js"></script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
 	<meta charset="UTF-8">
 	<title>Matter Game</title>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/matter-js/0.19.0/matter.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
 	<style>
 		body {
 			margin: 0;

--- a/index.html
+++ b/index.html
@@ -18,9 +18,47 @@
 </head>
 
 <body>
-
+	<div>
+		<label for="startPosition">Start Position (% across screen):</label>
+		<input type="range" id="startPosition" name="startPosition" min="0" max="100" value="25" style="width: 100%;">
+	</div>
+	<div>
+		<label for="targetPosition">Target Position (% across screen):</label>
+		<input type="range" id="targetPosition" name="targetPosition" min="0" max="100" value="75" style="width: 100%;">
+	</div>
+	<div>
+		<label for="speedMax">SpeedMaxOutput:</label>
+		<input type="number" id="speedMax" name="speedMax" value="100">
+		<label for="speedKp">speedkP:</label>
+		<input type="number" id="speedKp" name="speedKp" value="0">
+		<label for="speedKi">speedkI:</label>
+		<input type="number" id="speedKi" name="speedKi" value="0">
+		<label for="speedKd">speedkD:</label>
+		<input type="number" id="speedKd" name="speedKd" value="0">
+	</div>
+	<div>
+		<label for="angleMax">angleMaxOutput:</label>
+		<input type="number" id="angleMax" name="angleMax" value="50">
+		<label for="angleKp">anglekP:</label>
+		<input type="number" id="angleKp" name="angleKp" value="0">
+		<label for="angleKi">anglekI:</label>
+		<input type="number" id="angleKi" name="angleKi" value="0">
+		<label for="angleKd">anglekD:</label>
+		<input type="number" id="angleKd" name="angleKd" value="0">
+	</div>
+	<div>
+		<label for="forceMax">forceMaxOutput:</label>
+		<input type="number" id="forceMax" name="forceMax" value="20">
+		<label for="forceKp">forcekP:</label>
+		<input type="number" id="forceKp" name="forceKp" value="0">
+		<label for="forceKi">forcekI:</label>
+		<input type="number" id="forceKi" name="forceKi" value="0">
+		<label for="forceKd">forcekD:</label>
+		<input type="number" id="forceKd" name="forceKd" value="0">
+	</div>
+	<button id="resetSim">Reset Simulation</button>
+	<button id="updateSim">Update Target Position and PID Values</button>
 	<script type="module" src="matter_run.js"></script>
-
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -26,6 +26,10 @@
 		<input type="range" id="startPosition" name="startPosition" min="0" max="100" value="25" style="width: 100%;">
 	</div>
 	<div>
+		<label for="randomizeTarget">Randomize Target When Reached:</label>
+		<input type="checkbox" id="randomizeTarget" name="randomizeTarget">
+	</div>
+	<div>
 		<label for="targetPosition">Target Position (% across screen):</label>
 		<input type="range" id="targetPosition" name="targetPosition" min="0" max="100" value="75" style="width: 100%;">
 	</div>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
 		body {
 			margin: 0;
 			padding: 0;
+			background: #14151b;
+			color: #ffffff;
 		}
 
 		canvas {

--- a/matter_run.js
+++ b/matter_run.js
@@ -274,11 +274,28 @@ function applyForces(event) {
 
 Events.on(runner, 'afterUpdate', applyForces);
 
+const shouldRandomizeCheckbox = document.getElementById("randomizeTarget")
+let setTheTimeout = false;
 function checkIndicator() {
     if (Query.region([payload], indicator.bounds).includes(payload)) {
-        indicator.render.strokeStyle = colorOut;
-    } else {
         indicator.render.strokeStyle = colorIn;
+        if(!setTheTimeout && shouldRandomizeCheckbox.checked){
+            setTheTimeout = true;
+            setTimeout(() => {
+                // Randomize the target position when reached
+                setTheTimeout = false;
+                if(!Query.region([payload], indicator.bounds).includes(payload))
+                    return;
+                let newTarget = Math.random() * 100
+                targetPositionSlider.value = newTarget;
+                targetPosition = ((newTarget / 100) * WIDTH);
+                World.remove(engine.world, indicator);
+                indicator = Bodies.rectangle(targetPosition, INDICATOR_LEVEL, 15, 15, { isStatic: true, isSensor: true, render: { strokeStyle: colorOut, fillStyle: 'transparent', lineWidth: 2 } });
+                Composite.add(engine.world, [indicator]);
+            }, 1000 + (Math.random() * 5000))
+        }
+    } else {
+        indicator.render.strokeStyle = colorOut;
     }
 }
 

--- a/matter_run.js
+++ b/matter_run.js
@@ -9,7 +9,10 @@ const Engine = Matter.Engine,
     Query = Matter.Query,
     MouseConstraint = Matter.MouseConstraint,
     Constraint = Matter.Constraint,
-    Composite = Matter.Composite;
+    Composite = Matter.Composite,
+    World = Matter.World;
+
+const WIDTH = window.innerWidth;
 
 const engine = Engine.create();
 
@@ -17,8 +20,8 @@ const render = Render.create({
     element: document.body,
     engine: engine,
     options: {
-        width: 800,
-        height: 600,
+        width: WIDTH,
+        height: 800,
         // showAngleIndicator: true,
         showBounds: true,
         showPositions: false,
@@ -32,20 +35,26 @@ const render = Render.create({
 // const boxB = Bodies.rectangle(750, 50, 80, 80);
 // Composite.add(engine.world, [boxA, boxB]);
 
+const startPositionSlider = document.getElementById('startPosition');
+let startPosition = (parseFloat(startPositionSlider.value) / 100) * WIDTH;
+
+const targetPositionSlider = document.getElementById('targetPosition');
+let targetPosition = (parseFloat(targetPositionSlider.value) / 100) * WIDTH;
+
 const colorIn = '#f55a3c'
 const colorOut = '#f5d259'
-const indicator = Bodies.rectangle(500, 296, 15, 15, { isStatic: true, isSensor: true, render: { strokeStyle: colorOut, fillStyle: 'transparent', lineWidth: 2 } });
-const ground = Bodies.rectangle(400, 590, 8000, 10, { isStatic: true, angle: 0 });
+let indicator = Bodies.rectangle(targetPosition, 296, 15, 15, { isStatic: true, isSensor: true, render: { strokeStyle: colorOut, fillStyle: 'transparent', lineWidth: 2 } });
+let ground = Bodies.rectangle(400, 590, 8000, 10, { isStatic: true, angle: 0 });
 Composite.add(engine.world, [ground, indicator]);
 
-for (let i = 0; i < 20; i++) {
-    Composite.add(engine.world, [Bodies.rectangle(Common.random(100, 700), Common.random(300, 350), Common.random(3, 10), Common.random(3, 10), { friction: 0.4 })])
-}
+// for (let i = 0; i < 50; i++) {
+//     Composite.add(engine.world, [Bodies.rectangle(Common.random(100, 900), Common.random(300, 350), Common.random(3, 10), Common.random(3, 10), { friction: 0.4 })])
+// }
 
-const payload = Bodies.circle(200, 50, 10);
+let payload = Bodies.circle(startPosition, 330, 10);
 // Body.setMass(payload, 1)
-const wheel = Bodies.circle(200, 300, 40, { friction: 0.4, render: { sprite: { texture: 'assets/Stormcloud_Wheel.svg', xScale: 0.5, yScale: 0.5 } } });
-const join = Constraint.create({ bodyA: wheel, bodyB: payload, stiffness: 0.05, damping: 0.2 });
+let wheel = Bodies.circle(startPosition, 580, 40, { friction: 0.4, render: { sprite: { texture: 'assets/Stormcloud_Wheel.svg', xScale: 0.5, yScale: 0.5 } } });
+let join = Constraint.create({ bodyA: wheel, bodyB: payload, stiffness: 0.05, damping: 0.2 });
 Composite.add(engine.world, [payload, wheel, join]);
 
 Composite.add(engine.world, [MouseConstraint.create(engine)])
@@ -82,6 +91,40 @@ class ControlPID {
         this.accError = 0;
     }
 
+    reset() {
+        this.prevError = null;
+        this.accError = 0;
+    }
+
+    setMax(max) {
+        this.max = max;
+    }
+
+    setKp(kp) {
+        this.kp = kp;
+    }
+
+    setKi(ki) {
+        this.ki = ki;
+    }
+
+    setKd(kd) {
+        this.kd = kd;
+    }
+
+    setPID(kp, ki, kd) {
+        this.kp = kp;
+        this.ki = ki;
+        this.kd = kd;
+    }
+
+    setPIDWithMax(kp, ki, kd, max) {
+        this.kp = kp;
+        this.ki = ki;
+        this.kd = kd;
+        this.max = max;
+    }
+
     run(setPoint, process, delta) {
         const error = setPoint - process;
         const p = error
@@ -97,13 +140,124 @@ class ControlPID {
 }
 
 // TUNE HERE
-const speedControl = new ControlPID(100, 5, 0, 3)
-const angleControl = new ControlPID(30, 2, 0, 2)
-const forceControl = new ControlPID(20, -0.01, 0, -0.01)
+// const speedControl = new ControlPID(100, 5, 0, 3)
+// const angleControl = new ControlPID(30, 2, 0, 2)
+// const forceControl = new ControlPID(20, -0.01, 0, -0.01)
+
+const speedControl = new ControlPID(100, 0, 0, 0)
+const angleControl = new ControlPID(30, 0, 0, 0)
+const forceControl = new ControlPID(20, 0, 0, 0)
+
+const resetButton = document.getElementById('resetSim');
+resetButton.addEventListener('click', event => {
+    event.preventDefault();
+    World.clear(engine.world);
+    Engine.clear(engine);
+    Render.stop(render);
+    Runner.stop(runner);
+    
+    targetPosition = (parseFloat(targetPositionSlider.value) / 100) * WIDTH;
+    let indicator = Bodies.rectangle(targetPosition, 296, 15, 15, { isStatic: true, isSensor: true, render: { strokeStyle: colorOut, fillStyle: 'transparent', lineWidth: 2 } });
+    let ground = Bodies.rectangle(400, 590, 8000, 10, { isStatic: true, angle: 0 });
+    Composite.add(engine.world, [ground, indicator]);
+
+    startPosition = (parseFloat(startPositionSlider.value) / 100) * WIDTH;
+    payload = Bodies.circle(startPosition, 330, 10);
+    wheel = Bodies.circle(startPosition, 580, 40, { friction: 0.4, render: { sprite: { texture: 'assets/Stormcloud_Wheel.svg', xScale: 0.5, yScale: 0.5 } } });
+    join = Constraint.create({ bodyA: wheel, bodyB: payload, stiffness: 0.05, damping: 0.2 });
+    Composite.add(engine.world, [payload, wheel, join]);
+    Composite.add(engine.world, [MouseConstraint.create(engine)])
+    Render.run(render);
+    Runner.run(runner, engine);
+
+    // Speed control PID inputs
+    const speedKpInput = document.getElementById('speedKp');
+    const speedKiInput = document.getElementById('speedKi');
+    const speedKdInput = document.getElementById('speedKd');
+    const speedMaxInput = document.getElementById('speedMax');
+    const speedKp = parseFloat(speedKpInput.value);
+    const speedKi = parseFloat(speedKiInput.value);
+    const speedKd = parseFloat(speedKdInput.value);
+    const speedMax = parseFloat(speedMaxInput.value);
+
+    speedControl.setPIDWithMax(speedKp, speedKi, speedKd, speedMax);
+    speedControl.reset();
+
+    // Angle control PID inputs
+    const angleKpInput = document.getElementById('angleKp');
+    const angleKiInput = document.getElementById('angleKi');
+    const angleKdInput = document.getElementById('angleKd');
+    const angleMaxInput = document.getElementById('angleMax');
+    const angleKp = parseFloat(angleKpInput.value);
+    const angleKi = parseFloat(angleKiInput.value);
+    const angleKd = parseFloat(angleKdInput.value);
+    const angleMax = parseFloat(angleMaxInput.value);
+
+    angleControl.setPIDWithMax(angleKp, angleKi, angleKd, angleMax);
+    angleControl.reset();
+
+    // Force control PID inputs
+    const forceKpInput = document.getElementById('forceKp');
+    const forceKiInput = document.getElementById('forceKi');
+    const forceKdInput = document.getElementById('forceKd');
+    const forceMaxInput = document.getElementById('forceMax');
+    const forceKp = parseFloat(forceKpInput.value);
+    const forceKi = parseFloat(forceKiInput.value);
+    const forceKd = parseFloat(forceKdInput.value);
+    const forceMax = parseFloat(forceMaxInput.value);
+
+    forceControl.setPIDWithMax(forceKp, forceKi, forceKd, forceMax);
+    forceControl.reset();
+});
+
+const updateButton = document.getElementById('updateSim');
+updateButton.addEventListener('click', event => {
+    targetPosition = (parseFloat(targetPositionSlider.value) / 100) * WIDTH;
+    Body.setPosition(indicator, { x: targetPosition, y: indicator.position.y });
+
+    // Speed control PID inputs
+    const speedKpInput = document.getElementById('speedKp');
+    const speedKiInput = document.getElementById('speedKi');
+    const speedKdInput = document.getElementById('speedKd');
+    const speedMaxInput = document.getElementById('speedMax');
+    const speedKp = parseFloat(speedKpInput.value);
+    const speedKi = parseFloat(speedKiInput.value);
+    const speedKd = parseFloat(speedKdInput.value);
+    const speedMax = parseFloat(speedMaxInput.value);
+
+    speedControl.setPIDWithMax(speedKp, speedKi, speedKd, speedMax);
+    speedControl.reset();
+
+    // Angle control PID inputs
+    const angleKpInput = document.getElementById('angleKp');
+    const angleKiInput = document.getElementById('angleKi');
+    const angleKdInput = document.getElementById('angleKd');
+    const angleMaxInput = document.getElementById('angleMax');
+    const angleKp = parseFloat(angleKpInput.value);
+    const angleKi = parseFloat(angleKiInput.value);
+    const angleKd = parseFloat(angleKdInput.value);
+    const angleMax = parseFloat(angleMaxInput.value);
+
+    angleControl.setPIDWithMax(angleKp, angleKi, angleKd, angleMax);
+    angleControl.reset();
+
+    // Force control PID inputs
+    const forceKpInput = document.getElementById('forceKp');
+    const forceKiInput = document.getElementById('forceKi');
+    const forceKdInput = document.getElementById('forceKd');
+    const forceMaxInput = document.getElementById('forceMax');
+    const forceKp = parseFloat(forceKpInput.value);
+    const forceKi = parseFloat(forceKiInput.value);
+    const forceKd = parseFloat(forceKdInput.value);
+    const forceMax = parseFloat(forceMaxInput.value);
+
+    forceControl.setPIDWithMax(forceKp, forceKi, forceKd, forceMax);
+    forceControl.reset();
+});
 
 function applyForces(event) {
     const delta = event.source.delta;
-    const xGoal = 500
+    const xGoal = targetPosition;
     const speedGoal = speedControl.run(xGoal, payload.position.x, delta);
     const angleGoal = angleControl.run(speedGoal / delta, payload.velocity.x, delta);
     const force = forceControl.run(angleGoal, payload.position.x - wheel.position.x, delta);

--- a/matter_run.js
+++ b/matter_run.js
@@ -139,17 +139,73 @@ class ControlPID {
     }
 }
 
-// TUNE HERE
-// const speedControl = new ControlPID(100, 5, 0, 3)
-// const angleControl = new ControlPID(30, 2, 0, 2)
-// const forceControl = new ControlPID(20, -0.01, 0, -0.01)
-
 const speedControl = new ControlPID(100, 0, 0, 0)
 const angleControl = new ControlPID(30, 0, 0, 0)
 const forceControl = new ControlPID(20, 0, 0, 0)
 
+const speedKpInput = document.getElementById('speedKp');
+const speedKiInput = document.getElementById('speedKi');
+const speedKdInput = document.getElementById('speedKd');
+const speedMaxInput = document.getElementById('speedMax');
+
+const angleKpInput = document.getElementById('angleKp');
+const angleKiInput = document.getElementById('angleKi');
+const angleKdInput = document.getElementById('angleKd');
+const angleMaxInput = document.getElementById('angleMax');
+
+const forceKpInput = document.getElementById('forceKp');
+const forceKiInput = document.getElementById('forceKi');
+const forceKdInput = document.getElementById('forceKd');
+const forceMaxInput = document.getElementById('forceMax');
+
+
+const updateButton = document.getElementById('updateSim');
+updateButton.addEventListener('click', event => {
+    targetPosition = (parseFloat(targetPositionSlider.value) / 100) * WIDTH;
+    World.remove(engine.world, indicator);
+    indicator = Bodies.rectangle(targetPosition, 296, 15, 15, { isStatic: true, isSensor: true, render: { strokeStyle: colorOut, fillStyle: 'transparent', lineWidth: 2 } });
+    Composite.add(engine.world, indicator);
+
+    // Speed control PID inputs
+    const speedKp = parseFloat(speedKpInput.value);
+    const speedKi = parseFloat(speedKiInput.value);
+    const speedKd = parseFloat(speedKdInput.value);
+    const speedMax = parseFloat(speedMaxInput.value);
+
+    speedControl.setPIDWithMax(speedKp, speedKi, speedKd, speedMax);
+    speedControl.reset();
+
+    // Angle control PID inputs
+    const angleKpInput = document.getElementById('angleKp');
+    const angleKiInput = document.getElementById('angleKi');
+    const angleKdInput = document.getElementById('angleKd');
+    const angleMaxInput = document.getElementById('angleMax');
+    const angleKp = parseFloat(angleKpInput.value);
+    const angleKi = parseFloat(angleKiInput.value);
+    const angleKd = parseFloat(angleKdInput.value);
+    const angleMax = parseFloat(angleMaxInput.value);
+
+    angleControl.setPIDWithMax(angleKp, angleKi, angleKd, angleMax);
+    angleControl.reset();
+
+    // Force control PID inputs
+    const forceKpInput = document.getElementById('forceKp');
+    const forceKiInput = document.getElementById('forceKi');
+    const forceKdInput = document.getElementById('forceKd');
+    const forceMaxInput = document.getElementById('forceMax');
+    const forceKp = parseFloat(forceKpInput.value);
+    const forceKi = parseFloat(forceKiInput.value);
+    const forceKd = parseFloat(forceKdInput.value);
+    const forceMax = parseFloat(forceMaxInput.value);
+
+    forceControl.setPIDWithMax(forceKp, forceKi, forceKd, forceMax);
+    forceControl.reset();
+});
+
 const resetButton = document.getElementById('resetSim');
 resetButton.addEventListener('click', event => {
+    updateButton.click();
+
     event.preventDefault();
     World.clear(engine.world);
     Engine.clear(engine);
@@ -169,91 +225,29 @@ resetButton.addEventListener('click', event => {
     Composite.add(engine.world, [MouseConstraint.create(engine)])
     Render.run(render);
     Runner.run(runner, engine);
-
-    // Speed control PID inputs
-    const speedKpInput = document.getElementById('speedKp');
-    const speedKiInput = document.getElementById('speedKi');
-    const speedKdInput = document.getElementById('speedKd');
-    const speedMaxInput = document.getElementById('speedMax');
-    const speedKp = parseFloat(speedKpInput.value);
-    const speedKi = parseFloat(speedKiInput.value);
-    const speedKd = parseFloat(speedKdInput.value);
-    const speedMax = parseFloat(speedMaxInput.value);
-
-    speedControl.setPIDWithMax(speedKp, speedKi, speedKd, speedMax);
-    speedControl.reset();
-
-    // Angle control PID inputs
-    const angleKpInput = document.getElementById('angleKp');
-    const angleKiInput = document.getElementById('angleKi');
-    const angleKdInput = document.getElementById('angleKd');
-    const angleMaxInput = document.getElementById('angleMax');
-    const angleKp = parseFloat(angleKpInput.value);
-    const angleKi = parseFloat(angleKiInput.value);
-    const angleKd = parseFloat(angleKdInput.value);
-    const angleMax = parseFloat(angleMaxInput.value);
-
-    angleControl.setPIDWithMax(angleKp, angleKi, angleKd, angleMax);
-    angleControl.reset();
-
-    // Force control PID inputs
-    const forceKpInput = document.getElementById('forceKp');
-    const forceKiInput = document.getElementById('forceKi');
-    const forceKdInput = document.getElementById('forceKd');
-    const forceMaxInput = document.getElementById('forceMax');
-    const forceKp = parseFloat(forceKpInput.value);
-    const forceKi = parseFloat(forceKiInput.value);
-    const forceKd = parseFloat(forceKdInput.value);
-    const forceMax = parseFloat(forceMaxInput.value);
-
-    forceControl.setPIDWithMax(forceKp, forceKi, forceKd, forceMax);
-    forceControl.reset();
 });
 
-const updateButton = document.getElementById('updateSim');
-updateButton.addEventListener('click', event => {
-    targetPosition = (parseFloat(targetPositionSlider.value) / 100) * WIDTH;
-    Body.setPosition(indicator, { x: targetPosition, y: indicator.position.y });
+const setAcceptableValues = document.getElementById('setAcceptableValues');
+setAcceptableValues.addEventListener('click', event => {
+    // Set acceptable values for the PID inputs
+    speedKpInput.value = 5;
+    speedKiInput.value = 0;
+    speedKdInput.value = 3;
+    speedMaxInput.value = 100;
 
-    // Speed control PID inputs
-    const speedKpInput = document.getElementById('speedKp');
-    const speedKiInput = document.getElementById('speedKi');
-    const speedKdInput = document.getElementById('speedKd');
-    const speedMaxInput = document.getElementById('speedMax');
-    const speedKp = parseFloat(speedKpInput.value);
-    const speedKi = parseFloat(speedKiInput.value);
-    const speedKd = parseFloat(speedKdInput.value);
-    const speedMax = parseFloat(speedMaxInput.value);
+    angleKpInput.value = 2;
+    angleKiInput.value = 0;
+    angleKdInput.value = 2;
+    angleMaxInput.value = 30;
 
-    speedControl.setPIDWithMax(speedKp, speedKi, speedKd, speedMax);
-    speedControl.reset();
+    forceKpInput.value = -0.01;
+    forceKiInput.value = 0;
+    forceKdInput.value = -0.01;
+    forceMaxInput.value = 20;
 
-    // Angle control PID inputs
-    const angleKpInput = document.getElementById('angleKp');
-    const angleKiInput = document.getElementById('angleKi');
-    const angleKdInput = document.getElementById('angleKd');
-    const angleMaxInput = document.getElementById('angleMax');
-    const angleKp = parseFloat(angleKpInput.value);
-    const angleKi = parseFloat(angleKiInput.value);
-    const angleKd = parseFloat(angleKdInput.value);
-    const angleMax = parseFloat(angleMaxInput.value);
-
-    angleControl.setPIDWithMax(angleKp, angleKi, angleKd, angleMax);
-    angleControl.reset();
-
-    // Force control PID inputs
-    const forceKpInput = document.getElementById('forceKp');
-    const forceKiInput = document.getElementById('forceKi');
-    const forceKdInput = document.getElementById('forceKd');
-    const forceMaxInput = document.getElementById('forceMax');
-    const forceKp = parseFloat(forceKpInput.value);
-    const forceKi = parseFloat(forceKiInput.value);
-    const forceKd = parseFloat(forceKdInput.value);
-    const forceMax = parseFloat(forceMaxInput.value);
-
-    forceControl.setPIDWithMax(forceKp, forceKi, forceKd, forceMax);
-    forceControl.reset();
-});
+    // Trigger the reset button to reset the simulation
+    resetButton.click();
+})
 
 function applyForces(event) {
     const delta = event.source.delta;

--- a/matter_run.js
+++ b/matter_run.js
@@ -160,11 +160,11 @@ const forceMaxInput = document.getElementById('forceMax');
 
 
 const updateButton = document.getElementById('updateSim');
-updateButton.addEventListener('click', event => {
+updateButton.addEventListener('click', () => {
     targetPosition = (parseFloat(targetPositionSlider.value) / 100) * WIDTH;
     World.remove(engine.world, indicator);
     indicator = Bodies.rectangle(targetPosition, 296, 15, 15, { isStatic: true, isSensor: true, render: { strokeStyle: colorOut, fillStyle: 'transparent', lineWidth: 2 } });
-    Composite.add(engine.world, indicator);
+    Composite.add(engine.world, [indicator]);
 
     // Speed control PID inputs
     const speedKp = parseFloat(speedKpInput.value);
@@ -204,18 +204,17 @@ updateButton.addEventListener('click', event => {
 
 const resetButton = document.getElementById('resetSim');
 resetButton.addEventListener('click', event => {
-    updateButton.click();
-
     event.preventDefault();
     World.clear(engine.world);
     Engine.clear(engine);
     Render.stop(render);
     Runner.stop(runner);
     
+    updateButton.click();
     targetPosition = (parseFloat(targetPositionSlider.value) / 100) * WIDTH;
-    let indicator = Bodies.rectangle(targetPosition, 296, 15, 15, { isStatic: true, isSensor: true, render: { strokeStyle: colorOut, fillStyle: 'transparent', lineWidth: 2 } });
+    // We don't need to add the indicator here as it is added in updateButton.click()
     let ground = Bodies.rectangle(400, 590, 8000, 10, { isStatic: true, angle: 0 });
-    Composite.add(engine.world, [ground, indicator]);
+    Composite.add(engine.world, [ground]);
 
     startPosition = (parseFloat(startPositionSlider.value) / 100) * WIDTH;
     payload = Bodies.circle(startPosition, 330, 10);
@@ -228,7 +227,7 @@ resetButton.addEventListener('click', event => {
 });
 
 const setAcceptableValues = document.getElementById('setAcceptableValues');
-setAcceptableValues.addEventListener('click', event => {
+setAcceptableValues.addEventListener('click', () => {
     // Set acceptable values for the PID inputs
     speedKpInput.value = 5;
     speedKiInput.value = 0;
@@ -260,7 +259,7 @@ function applyForces(event) {
 
 Events.on(runner, 'afterUpdate', applyForces);
 
-function checkIndicator(event) {
+function checkIndicator() {
     if (Query.region([payload], indicator.bounds).includes(payload)) {
         indicator.render.strokeStyle = colorOut;
     } else {


### PR DESCRIPTION
## Additions
- Max Value, kP, kI, kD inputs for each PID controller on the webUI
- Reset Simulation button
  - Resets the simulation using the current values
- Update Target Position and PID Values button
  - Updates the PID parameters and moves the target without resetting the inverted pendulum itself
- Set Parameters to Usable Values button
  - Sets some default values that work fairly well
- A graph to track current position and current target over time
  - Toggled visibility using a checkbox under the simulation window
- A graph to track PID controller outputs over time 
  - Toggled visibility using a checkbox under the simulation window
- A check box to randomize the target if the payload has been stable within the target
  - Checked by using setTimeout to check randomly between 1 second and 6 seconds after the payload touches the target to see if it is still in the target, if it is, move target, otherwise start a new timeout
## Changes
- PID controllers have all P, I, and D values initialized as 0. Use the Set Parameters to Usable Values button to set the values to the old defaults